### PR TITLE
Capitalised the label to match gedit style

### DIFF
--- a/wordcount.py
+++ b/wordcount.py
@@ -57,5 +57,5 @@ class WordcountPlugin(GObject.Object, Gedit.WindowActivatable):
     def update_label(self, doc):
         """update the plugins status bar label"""
         txt = get_text(doc)
-        msg = 'words: {0}'.format(len(WORD_RE.findall(txt)))
+        msg = 'Words: {0}'.format(len(WORD_RE.findall(txt)))
         self._label.set_text(msg)


### PR DESCRIPTION
Tiny, _tiny_ little change: the rest of the labels in the gedit status bar are in Intial Caps, but the wordcount-plugin label was in lowercase. This change gives it a capital W, to match the gedit label style. (Told you it was tiny. What can I say?)
